### PR TITLE
Correct z-index order of site tree sidebar elements

### DIFF
--- a/_build/assets/sass/_sidebar.scss
+++ b/_build/assets/sass/_sidebar.scss
@@ -367,6 +367,7 @@
         transition: $timing;
         cursor: pointer;
         color: $black;
+        z-index: 4;
         &.active {
           color: $white;
           background-color: $dark-gray;


### PR DESCRIPTION
Within the site tree sidebar, hidden child menus are overlaying sibling parent buttons making them un-clickable. The z-index applied here is the cause:
https://github.com/modxcms/fred/blob/097edb09fbca813fa89071bd53864ab4af988d00/_build/assets/sass/_sidebar.scss#L361-L362

This pr corrects it by applying a z-index to the parent buttons.

Resolves: https://github.com/modxcms/fred/issues/245