### PR TITLE
Fix site tree padding

### DIFF
--- a/_build/assets/sass/_buttons.scss
+++ b/_build/assets/sass/_buttons.scss
@@ -7,7 +7,7 @@ button.fred--btn, .fred--btn, .fred button.fred--btn, .fred .fred--btn{
     color: $white;
     background-color: darken($primary, 10%);
   }
-  
+
   @include btn-disabled();
 
   &-small {
@@ -156,7 +156,7 @@ button.fred--btn, .fred--btn, .fred button.fred--btn, .fred .fred--btn{
     height: 30px;
     width: 30px;
     left: 6px;
-    top: calc(50% - 10px);
+    top: calc(50% - 15px);
     cursor: pointer !important;
     color: $black;
     &_expand {

--- a/_build/assets/sass/_sidebar.scss
+++ b/_build/assets/sass/_sidebar.scss
@@ -451,8 +451,8 @@
 .fred--accordion dd .fred--pages {
   dl.fred--pages_list {
     dt:not([class^="fred--accordion"]){
-      padding: 12px 30px 0 33px;
-      margin-bottom: -3px;
+      padding: 5px 30px 5px 33px;
+      margin-bottom: 0;
       outline:none;
       &:before{
         display:none;


### PR DESCRIPTION
Evens out the padding on buttons in the site tree which smartens up the hover state.

Can this be squeezed into beta-4 release?