### PR TITLE
PR to allow Fred to work with Static Site Cache

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -23,6 +23,7 @@
             "OnDocFormPrerender",
             "OnDocFormSave",
             "OnBeforeDocFormSave",
+            "OnPageNotFound",
             "OnTemplateRemove",
             "OnTVInputRenderList",
             "OnTVInputPropertiesList",
@@ -79,6 +80,12 @@
         "key": "default_enabled",
         "type" : "combo-boolean",
         "value": "1"
+      },
+      {
+        "area": "Manager",
+        "key": "use_custom_editor_url",
+        "type" : "combo-boolean",
+        "value": "0"
       }
     ]
   },

--- a/core/components/fred/elements/plugins/Fred.php
+++ b/core/components/fred/elements/plugins/Fred.php
@@ -35,7 +35,7 @@ switch ($modx->event->name) {
             //Load Open in Fred button
             $modx->lexicon->load('fred:default');
             $modx->controller->addLexiconTopic('fred:default');
-            // @TODO make a fred preview URL:
+
             $preview_url = 'panel.config.preview_url';
             if ($modx->getOption('fred.use_custom_editor_url')) {
                 $preview_url = "'".rtrim($modx->makeUrl($modx->getOption('site_start')), '/')."/fred-editor-".$resource->get('id')."'";
@@ -50,7 +50,7 @@ switch ($modx->event->name) {
                     panel = Ext.getCmp('modx-page-update-resource'); 
                     
                     content.destroy();
-                    // LCI FRED?
+
                     right.insert(0,{
                         xtype: 'button' 
                         ,fieldLabel: _('fred.open_in_fred')

--- a/core/components/fred/lexicon/en/default.inc.php
+++ b/core/components/fred/lexicon/en/default.inc.php
@@ -257,6 +257,8 @@ $_lang['setting_fred.secret'] = 'Secret';
 $_lang['setting_fred.secret_desc'] = 'Secret used in signing XHR requests';
 $_lang['setting_fred.default_enabled'] = 'Fred Enabled';
 $_lang['setting_fred.default_enabled_desc'] = 'Enable or Disable Fred by default';
+$_lang['setting_fred.use_custom_editor_url'] = 'Use custom Fred editor URLs';
+$_lang['setting_fred.use_custom_editor_url_desc'] = 'Requires friendly URLs. If yes opening Fred links from a Resource will be unique to Fred. Ex: www.yoursite.com/fred-editor-123 Helpful for static site generators.';
 
 $_lang['fred.err.blueprint_categories_ns_name'] = 'Name is required';
 $_lang['fred.err.blueprints_ns_name'] = 'Name is required';


### PR DESCRIPTION
## This PR does the following:

1. Add a new system setting: `(bool) fred.use_custom_editor_url` 
2. When `use_custom_editor_url` is 1/true then the `Open in Fred` button will launch Fred on it on custom URL as to not intefer with the normal URL routes and caching. Ex: www.yoursite.com/fred-editor-123
3. The Fred plugin is now listening for the `OnPageNotFound` 
  Helpful for static site generators.';
4. The Fred plugin for the event OnWebPagePrerender temporarily sets the resource to not cacheable via: `$modx->resource->cacheable = 0;`. This prevents extras from doing a full page cache of the Fred JS.

Related: https://github.com/LippertComponents/Stockpile/compare/v1.3.3...v1.4.0

## Why is this needed?

Static caching extras like [StatCache](https://github.com/opengeek/statcache) and [Stockpile Static generator](https://github.com/LippertComponents/Stockpile) cannot be used with the current version of Fred.

This simple solution just loads the resource up in a custom Fred URL from the manager button to preserve all Fred JS and events and also allows the static versions to remain as they are and not cache the Fred editor view/code.