### PR TITLE
Keep newlines when pasting content

### DIFF
--- a/_build/assets/js/Content/Element.js
+++ b/_build/assets/js/Content/Element.js
@@ -708,7 +708,7 @@ export class Element {
                         e.preventDefault();
                         const text = (e.originalEvent || e).clipboardData.getData('text/plain');
 
-                        document.execCommand("insertHTML", false, text);
+                        document.execCommand("insertText", false, text);
                     });
 
                     el.addEventListener('keydown', e => {


### PR DESCRIPTION
The content is retrieved as text/plain, therefore we should also insert it as text.

Resolves issue #327