### PR TITLE
Fix install for MODX 3

### DIFF
--- a/_build/scripts/before.acls.php
+++ b/_build/scripts/before.acls.php
@@ -24,7 +24,7 @@ switch ($options[xPDOTransport::PACKAGE_ACTION]) {
     case xPDOTransport::ACTION_INSTALL:
     case xPDOTransport::ACTION_UPGRADE:
 
-        $group = $modx->getObject(modAccessPolicyTemplateGroup::class, ['name' => 'Admin']);
+        $group = $modx->getObject(modAccessPolicyTemplateGroup::class, ['name' => 'Administrator']);
         if (!$group) return;
 
         /** @var modAccessPolicyTemplate $template */

--- a/_build/scripts/before.customevents.php
+++ b/_build/scripts/before.customevents.php
@@ -10,7 +10,7 @@ use xPDO\Transport\xPDOTransport;
  */
 
 
-if ($object->xpdo) {
+if ($transport->xpdo) {
     /** @var modX $modx */
     $modx =& $transport->xpdo;
 


### PR DESCRIPTION
When installing Fred 2.0.1 on MODX 3 there are the following errors in the console:

```
PHP notice: Trying to get property 'xpdo' of non-object
xPDOScriptVehicle execution failed: (C:\wamp64\www\modx301c/core/packages/fred-2.0.1-pl/xPDO/Transport/xPDOScriptVehicle/d6cc5d80772ddab35d81525ffc57c217.before.acls.script)
```
The Access-Policy-Template-Group for Administrators now seems to be called "Administrator" in MODX 3 (and not "Admin" anymore as in MODX 2.x).

This should resolve issues #444 and #426.
