### PR TITLE
Fix processor classes for RTE Configs in MODX 2.x

### DIFF
--- a/core/components/fred/processors/mgr/element_rte_configs/create.class.php
+++ b/core/components/fred/processors/mgr/element_rte_configs/create.class.php
@@ -2,4 +2,4 @@
 
 require_once(dirname(__FILE__, 4) . '/vendor/autoload.php');
 
-return \Fred\v2\Processors\ElementOptionSets\Create::class;
+return \Fred\v2\Processors\ElementRTEConfigs\Create::class;

--- a/core/components/fred/processors/mgr/element_rte_configs/duplicate.class.php
+++ b/core/components/fred/processors/mgr/element_rte_configs/duplicate.class.php
@@ -2,4 +2,4 @@
 
 require_once(dirname(__FILE__, 4) . '/vendor/autoload.php');
 
-return \Fred\v2\Processors\ElementOptionSets\Duplicate::class;
+return \Fred\v2\Processors\ElementRTEConfigs\Duplicate::class;

--- a/core/components/fred/processors/mgr/element_rte_configs/get.class.php
+++ b/core/components/fred/processors/mgr/element_rte_configs/get.class.php
@@ -2,4 +2,4 @@
 
 require_once(dirname(__FILE__, 4) . '/vendor/autoload.php');
 
-return \Fred\v2\Processors\ElementOptionSets\Get::class;
+return \Fred\v2\Processors\ElementRTEConfigs\Get::class;

--- a/core/components/fred/processors/mgr/element_rte_configs/getlist.class.php
+++ b/core/components/fred/processors/mgr/element_rte_configs/getlist.class.php
@@ -2,4 +2,4 @@
 
 require_once(dirname(__FILE__, 4) . '/vendor/autoload.php');
 
-return \Fred\v2\Processors\ElementOptionSets\GetList::class;
+return \Fred\v2\Processors\ElementRTEConfigs\GetList::class;

--- a/core/components/fred/processors/mgr/element_rte_configs/remove.class.php
+++ b/core/components/fred/processors/mgr/element_rte_configs/remove.class.php
@@ -2,4 +2,4 @@
 
 require_once(dirname(__FILE__, 4) . '/vendor/autoload.php');
 
-return \Fred\v2\Processors\ElementOptionSets\Remove::class;
+return \Fred\v2\Processors\ElementRTEConfigs\Remove::class;

--- a/core/components/fred/processors/mgr/element_rte_configs/update.class.php
+++ b/core/components/fred/processors/mgr/element_rte_configs/update.class.php
@@ -2,4 +2,4 @@
 
 require_once(dirname(__FILE__, 4) . '/vendor/autoload.php');
 
-return \Fred\v2\Processors\ElementOptionSets\Update::class;
+return \Fred\v2\Processors\ElementRTEConfigs\Update::class;

--- a/core/components/fred/processors/mgr/element_rte_configs/updatefromgrid.class.php
+++ b/core/components/fred/processors/mgr/element_rte_configs/updatefromgrid.class.php
@@ -2,4 +2,4 @@
 
 require_once(dirname(__FILE__, 4) . '/vendor/autoload.php');
 
-return \Fred\v2\Processors\ElementOptionSets\UpdateFromGrid::class;
+return \Fred\v2\Processors\ElementRTEConfigs\UpdateFromGrid::class;


### PR DESCRIPTION
In MODX 2.x, the wrong processors are used when handling RTE Configs in the manager.

Related forum topic: https://community.modx.com/t/problem-upgrading-fred-to-version-3-0-in-modx-2-8-7/7915/6

Fred 3.0.0-pl
MODX 2.8.7-pl