### PR TITLE
Fix fatal error "Class modRequest not found" in MODX 2.x

### DIFF
--- a/core/components/fred/src/v2/Endpoint/Ajax/RenderElement.php
+++ b/core/components/fred/src/v2/Endpoint/Ajax/RenderElement.php
@@ -19,4 +19,11 @@ class RenderElement extends Endpoint
     private $elementClass = 'FredElement';
     private $requestClass = 'modRequest';
     private $resourceClass = 'modResource';
+
+    public function __construct(\Fred &$fred, $payload)
+    {
+        parent::__construct($fred, $payload);
+        $this->modx->loadClass($this->requestClass, '', false, true);
+    }
+
 }


### PR DESCRIPTION
In MODX 2.x, when rendering an element on the front-end (`assets/components/fred/web/endpoints/ajax.php?modx=2&action=render-element`) a fatal error occurs:

```
Fatal error: Uncaught Error: Class 'modRequest' not found in .../core/components/fred/src/Traits/Endpoint/Ajax/RenderElement.php:119
Stack trace:
#0 .../core/components/fred/src/Traits/Endpoint/Ajax/Endpoint.php(40): Fred/v2/Endpoint/Ajax/RenderElement->process()
#1 .../core/components/fred/src/v2/Endpoint/Ajax.php(64): Fred/v2/Endpoint/Ajax/Endpoint->run()
#2 .../assets/components/fred/web/endpoints/ajax.php(22): Fred/v2/Endpoint/Ajax->run()
```

Related forum topic: https://community.modx.com/t/problem-upgrading-fred-to-version-3-0-in-modx-2-8-7/7915/13

Fred 3.0.0-pl
MODX 2.8.7-pl
