### PR TITLE
Fix removing source path from image TV value in MODX 2.x

### DIFF
--- a/core/components/fred/src/Traits/RenderResource.php
+++ b/core/components/fred/src/Traits/RenderResource.php
@@ -425,13 +425,20 @@ trait RenderResource
         if (!empty($value)) {
             $context = !empty($resource) ? $resource->get('context_key') : $this->modx->context->get('key');
             $sourceCache = $tv->getSourceCache($context);
-            $classKey = $sourceCache['class_key'];
+            $classKey = $sourceCache['source_class_key'];
             if (!empty($sourceCache) && !empty($classKey)) {
                 if ($this->modx->loadClass($classKey)) {
                     $source = $this->modx->newObject($classKey);
                     if ($source) {
                         $source->fromArray($sourceCache, '', true, true);
                         $source->initialize();
+                        $bases = $source->getBases();
+                        if (!empty($bases['urlAbsolute'])) {
+                            $url = $bases['urlAbsolute'];
+                            if (substr($value, 0, strlen($url)) === $url) {
+                                return substr($value, strlen($url));
+                            }
+                        }
                         $properties = $source->getPropertyList();
                         if (!empty($properties['baseUrl'])) {
                             // remove the base url from the front of the value


### PR DESCRIPTION
In MODX 2.x, when an image TV has a source assigned, the source path isn't removed correctly from the TV value when the resource is saved in the front-end.

1. The code tries to load the class "modFileMediaSource" instead of "sources.modFileMediaSource", which creates the error `Could not load class: modFileMediaSource from mysql.modfilemediasource.`
2. Sometimes the TV values contains also the MODX base URL (`MODX_BASE_URL`), sometimes only the Media-Source baseUrl.

Related forum topic: https://community.modx.com/t/trouble-getting-fred-to-save-correct-path-to-image/7917

Fred 3.0.0-pl
MODX 2.8.7-pl

---

This fix might not work in MODX 3, as I haven't tested it!
