### PR TITLE
Fix ACLs resolver for MODX 3

### DIFF
--- a/_build/resolvers/resolve.acls.php
+++ b/_build/resolvers/resolve.acls.php
@@ -9,6 +9,9 @@ if ($object->xpdo) {
         case xPDOTransport::ACTION_UPGRADE:
             $group = $modx->getObject('modAccessPolicyTemplateGroup', ['name' => 'Admin']);
             if (!$group) {
+                $group = $modx->getObject('modAccessPolicyTemplateGroup', ['name' => 'Administrator']);
+            }
+            if (!$group) {
                 return;
             }
 


### PR DESCRIPTION
During the installation, the ACLs resolver fails in MODX 3.

```
xPDOVehicle resolver failed: type php (C:\wamp64\www\modx305c/core/packages/fred-3.0.0-pl/modCategory/35c5d4e913910b8464491d5b6158c2d0.resolve.acls.resolver)
```

The Access-Policy-Template-Group for Administrators is called "Administrator" in MODX 3.

I already fixed this once before: #445

Related forum topic: https://community.modx.com/t/modx-fred-not-showing-up-under-extras-when-installed/7927