### PR TITLE
feat: parse Template Variable options

### DIFF
--- a/core/components/fred/src/Traits/Endpoint/Ajax/LoadContent.php
+++ b/core/components/fred/src/Traits/Endpoint/Ajax/LoadContent.php
@@ -97,11 +97,13 @@ trait LoadContent
                 ];
 
                 if (!empty($props['fred.options'])) {
-                    $def['options'] = json_decode($props['fred.options']);
+                    $v = \Fred\Utils::modxParseString($this->modx, $props['fred.options']);
+                    $def['options'] = json_decode($v);
                     unset($props['fred.options']);
                 }
                 foreach ($props as $k => $v) {
                     if (substr($k, 0, 5) === "fred.") {
+                        $v = \Fred\Utils::modxParseString($this->modx, $v);
                         $def[substr($k, 5)] = $v;
                     }
                 }

--- a/core/components/fred/src/Utils.php
+++ b/core/components/fred/src/Utils.php
@@ -83,13 +83,18 @@ final class Utils
             $data = json_encode($data);
         }
         /** @var \MODX\Revolution\modChunk $chunk */
-        $chunk = $modx->newObject('modChunk', ['name' => 'inline-' . uniqid()]);
+        $chunk = $modx->newObject('modChunk', ['name' => 'inline-' . uniqid('', true)]);
         $chunk->setCacheable(false);
 
         $output = $chunk->process($phs, $data);
 
         if ($isArray === true) {
-            $output = json_decode($output, true);
+            try {
+                $output = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+            } catch (\JsonException $e) {
+                $modx->log(\modX::LOG_LEVEL_ERROR, 'Failed to parse JSON string: ' . $e->getMessage());
+                return [];
+            }
         }
 
         return $output;


### PR DESCRIPTION
This ports the parser from element settings to template variable settings. E.g. you can have a `fred.options` TV property setting that is a chunk or snippet that returns a JSON array. 