### PR TITLE
feat: split resources into batches during regeneration

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -3,7 +3,7 @@
   "lowCaseName": "fred",
   "description": "Frontend Editor",
   "author": "John Peca",
-  "version": "3.1.6-pl",
+  "version": "3.2.0-pl",
   "package": {
     "menus": [
       {
@@ -99,6 +99,11 @@
       {
         "key": "lit",
         "value": "0"
+      },
+      {
+        "key": "batch_size",
+        "value": "10",
+        "type": "numberfield"
       }
     ]
   },

--- a/_build/gpm.json
+++ b/_build/gpm.json
@@ -3,7 +3,7 @@
   "lowCaseName": "fred",
   "description": "Frontend Editor",
   "author": "John Peca",
-  "version": "3.1.6-pl",
+  "version": "3.2.0-pl",
   "menus": [
     {
       "text": "fred.menu.fred",
@@ -95,6 +95,11 @@
     {
       "key": "lit",
       "value": "0"
+    },
+    {
+      "key": "batch_size",
+      "value": "10",
+      "type": "numberfield"
     }
   ],
   "database": {

--- a/assets/components/fred/mgr/js/home/panel.js
+++ b/assets/components/fred/mgr/js/home/panel.js
@@ -233,30 +233,81 @@ Ext.extend(fred.panel.Home, MODx.Panel, {
                                 text: _('fred.rebuild.rebuild'),
                                 handler: function() {
                                     var topic = '/fred/mgr/generate/refresh/';
+                                    var batchSize = MODx.config.fred.batch_size || 10;
+                                    var offset = 0;
+                                    var total = 0;
 
-                                    var console = MODx.load({
+                                    var consoleWin = MODx.load({
                                         xtype: 'modx-console',
                                         register: 'mgr',
                                         topic: topic,
                                         show_filename: 0
                                     });
 
-                                    console.show(Ext.getBody());
+                                    consoleWin.show(Ext.getBody());
+
+                                    function processNextBatch() {
+                                        var isLast = (offset + batchSize) >= total;
+                                        MODx.Ajax.request({
+                                            url: fred.config.connectorUrl,
+                                            params: {
+                                                action: 'Fred\\Processors\\Generate\\Refresh',
+                                                register: 'mgr',
+                                                topic: topic,
+                                                offset: offset,
+                                                limit: batchSize,
+                                                isLast: isLast ? 1 : 0
+                                            },
+                                            listeners: {
+                                                success: {
+                                                    fn: function() {
+                                                        offset += batchSize;
+                                                        if (offset < total) {
+                                                            processNextBatch();
+                                                        } else {
+                                                            consoleWin.fireEvent('complete');
+                                                            consoleWin = null;
+                                                        }
+                                                    },
+                                                    scope: this
+                                                },
+                                                failure: {
+                                                    fn: function() {
+                                                        consoleWin.fireEvent('complete');
+                                                        consoleWin = null;
+                                                    },
+                                                    scope: this
+                                                }
+                                            }
+                                        });
+                                    }
 
                                     MODx.Ajax.request({
                                         url: fred.config.connectorUrl,
                                         params: {
-                                            action: 'Fred\\Processors\\Generate\\Refresh',
+                                            action: 'Fred\\Processors\\Generate\\Count',
                                             register: 'mgr',
                                             topic: topic
                                         },
                                         listeners: {
                                             success: {
-                                                fn: function() {
-                                                    console.fireEvent('complete');
-                                                    console = null
+                                                fn: function(r) {
+                                                    total = r.object.total;
+                                                    if (total === 0) {
+                                                        consoleWin.fireEvent('complete');
+                                                        consoleWin = null;
+                                                        return;
+                                                    }
+                                                    processNextBatch();
                                                 },
-                                                scope:this
+                                                scope: this
+                                            },
+                                            failure: {
+                                                fn: function() {
+                                                    consoleWin.fireEvent('complete');
+                                                    consoleWin = null;
+                                                },
+                                                scope: this
                                             }
                                         }
                                     });

--- a/assets/components/fred/mgr/js/home/panel.js
+++ b/assets/components/fred/mgr/js/home/panel.js
@@ -229,13 +229,25 @@ Ext.extend(fred.panel.Home, MODx.Panel, {
                                 html: '<p>' + _('fred.rebuild.rebuild_desc') + '</p><br>'
                             },
                             {
+                                xtype: 'fred-combo-themes',
+                                id: 'fred-rebuild-theme',
+                                fieldLabel: _('fred.rebuild.theme'),
+                                isUpdate: true,
+                                addAll: 1,
+                                width: 300,
+                                allowBlank: true
+                            },
+                            {
                                 xtype: 'button',
                                 text: _('fred.rebuild.rebuild'),
+                                style: 'margin-top: 10px',
                                 handler: function() {
                                     var topic = '/fred/mgr/generate/refresh/';
-                                    var batchSize = MODx.config.fred.batch_size || 10;
+                                    var batchSize = MODx.config['fred.batch_size'] || 10;
                                     var offset = 0;
                                     var total = 0;
+                                    var themeCombo = Ext.getCmp('fred-rebuild-theme');
+                                    var theme = themeCombo ? (themeCombo.getValue() || 0) : 0;
 
                                     var consoleWin = MODx.load({
                                         xtype: 'modx-console',
@@ -256,7 +268,8 @@ Ext.extend(fred.panel.Home, MODx.Panel, {
                                                 topic: topic,
                                                 offset: offset,
                                                 limit: batchSize,
-                                                isLast: isLast ? 1 : 0
+                                                isLast: isLast ? 1 : 0,
+                                                theme: theme
                                             },
                                             listeners: {
                                                 success: {
@@ -287,7 +300,8 @@ Ext.extend(fred.panel.Home, MODx.Panel, {
                                         params: {
                                             action: 'Fred\\Processors\\Generate\\Count',
                                             register: 'mgr',
-                                            topic: topic
+                                            topic: topic,
+                                            theme: theme
                                         },
                                         listeners: {
                                             success: {

--- a/core/components/fred/lexicon/en/default.inc.php
+++ b/core/components/fred/lexicon/en/default.inc.php
@@ -106,6 +106,7 @@ $_lang['fred.elements.templates'] = 'Templates';
 
 $_lang['fred.rebuild.rebuild'] = 'Rebuild';
 $_lang['fred.rebuild.rebuild_desc'] = 'Click the Rebuild button below to publish the changes in updated Elements to all existing Fred-powerd site pages.';
+$_lang['fred.rebuild.theme'] = 'Theme';
 
 $_lang['fred.element_cateogries.all'] = 'All Categories';
 $_lang['fred.element_categories.none'] = 'No Categories were found.';

--- a/core/components/fred/lexicon/en/default.inc.php
+++ b/core/components/fred/lexicon/en/default.inc.php
@@ -272,6 +272,8 @@ $_lang['setting_fred.force_sidebar'] = 'Force Sidebar';
 $_lang['setting_fred.force_sidebar_desc'] = 'When enabled, user won\'t be able to close the sidebar.';
 $_lang['setting_fred.logout_url'] = 'Logout Link';
 $_lang['setting_fred.logout_url_desc'] = 'Custom logout link. If filled, users will redirect there instead of to the manager logout after clicking the logout button.';
+$_lang['setting_fred.batch_size'] = 'Regenerate Batch Size';
+$_lang['setting_fred.batch_size_desc'] = 'Maximum number of resources to process in a single batch when regenerating (set to lower values to increase performance).';
 
 $_lang['fred.err.blueprint_categories_ns_name'] = 'Name is required';
 $_lang['fred.err.blueprints_ns_name'] = 'Name is required';

--- a/core/components/fred/processors/mgr/generate/count.class.php
+++ b/core/components/fred/processors/mgr/generate/count.class.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once(dirname(__FILE__, 4) . '/vendor/autoload.php');
+
+return \Fred\v2\Processors\Generate\Count::class;

--- a/core/components/fred/src/Processors/Generate/Count.php
+++ b/core/components/fred/src/Processors/Generate/Count.php
@@ -15,8 +15,13 @@ class Count extends Processor
 
     public function process()
     {
+        $theme = (int)$this->getProperty('theme', 0);
+
         $c = $this->modx->newQuery(FredThemedTemplate::class);
         $c->select($this->modx->getSelectColumns(FredThemedTemplate::class, 'FredThemedTemplate', '', ['template']));
+        if ($theme > 0) {
+            $c->where(['theme' => $theme]);
+        }
         $c->prepare();
         $c->stmt->execute();
 

--- a/core/components/fred/src/Processors/Generate/Count.php
+++ b/core/components/fred/src/Processors/Generate/Count.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Fred\Processors\Generate;
+
+use Fred\Model\FredThemedTemplate;
+use MODX\Revolution\modResource;
+use MODX\Revolution\Processors\Processor;
+
+class Count extends Processor
+{
+    public function checkPermissions()
+    {
+        return $this->modx->hasPermission('empty_cache');
+    }
+
+    public function process()
+    {
+        $c = $this->modx->newQuery(FredThemedTemplate::class);
+        $c->select($this->modx->getSelectColumns(FredThemedTemplate::class, 'FredThemedTemplate', '', ['template']));
+        $c->prepare();
+        $c->stmt->execute();
+
+        $templates = $c->stmt->fetchAll(\PDO::FETCH_COLUMN, 0);
+        $templates = array_map('intval', $templates);
+        $templates = array_filter($templates);
+
+        if (empty($templates)) {
+            return $this->failure($this->modx->lexicon('fred.refresh_fail_template'));
+        }
+
+        $count = $this->modx->getCount(modResource::class, ['template:IN' => $templates]);
+
+        return $this->success('', ['total' => (int)$count]);
+    }
+}

--- a/core/components/fred/src/Processors/Generate/Refresh.php
+++ b/core/components/fred/src/Processors/Generate/Refresh.php
@@ -20,13 +20,15 @@ class Refresh extends Processor
 
     public function process()
     {
-        //allow larger sites to rebuild
-        ini_set('max_execution_time', 300);
-        /** @var Fred $fred */
-        $fred =  $this->modx->services->get('fred');
+        ini_set('max_execution_time', 30);
 
-        //Clear Element Values
-        $this->modx->removeCollection(FredCache::class, []);
+        $offset = (int)$this->getProperty('offset', 0);
+        $limit = (int)$this->getProperty('limit', 10);
+        $isLast = (bool)$this->getProperty('isLast', false);
+
+        if ($offset === 0) {
+            $this->modx->removeCollection(FredCache::class, []);
+        }
 
         $c = $this->modx->newQuery(FredThemedTemplate::class);
         $c->select($this->modx->getSelectColumns(FredThemedTemplate::class, 'FredThemedTemplate', '', ['template']));
@@ -44,6 +46,7 @@ class Refresh extends Processor
 
         $c = $this->modx->newQuery(modResource::class);
         $c->where(['template:IN' => $templates]);
+        $c->limit($limit, $offset);
         $results = $this->modx->getIterator(modResource::class, $c);
 
         foreach ($results as $resource) {
@@ -86,7 +89,9 @@ class Refresh extends Processor
             $this->modx->log(modX::LOG_LEVEL_INFO, $this->modx->lexicon('fred.refresh_id', ['id' => $resource->id]));
         }
 
-        $this->modx->log(modX::LOG_LEVEL_INFO, $this->modx->lexicon('fred.refresh_complete'));
+        if ($isLast) {
+            $this->modx->log(modX::LOG_LEVEL_INFO, $this->modx->lexicon('fred.refresh_complete'));
+        }
 
         return $this->success('');
     }

--- a/core/components/fred/src/Processors/Generate/Refresh.php
+++ b/core/components/fred/src/Processors/Generate/Refresh.php
@@ -25,6 +25,7 @@ class Refresh extends Processor
         $offset = (int)$this->getProperty('offset', 0);
         $limit = (int)$this->getProperty('limit', 10);
         $isLast = (bool)$this->getProperty('isLast', false);
+        $theme = (int)$this->getProperty('theme', 0);
 
         if ($offset === 0) {
             $this->modx->removeCollection(FredCache::class, []);
@@ -32,6 +33,9 @@ class Refresh extends Processor
 
         $c = $this->modx->newQuery(FredThemedTemplate::class);
         $c->select($this->modx->getSelectColumns(FredThemedTemplate::class, 'FredThemedTemplate', '', ['template']));
+        if ($theme > 0) {
+            $c->where(['theme' => $theme]);
+        }
 
         $c->prepare();
         $c->stmt->execute();

--- a/core/components/fred/src/v2/Processors/Generate/Count.php
+++ b/core/components/fred/src/v2/Processors/Generate/Count.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Fred\v2\Processors\Generate;
+
+/**
+ * @package fred
+ * @subpackage processors
+ */
+class Count extends \modProcessor
+{
+    public function checkPermissions()
+    {
+        return $this->modx->hasPermission('empty_cache');
+    }
+
+    public function process()
+    {
+        $c = $this->modx->newQuery('FredThemedTemplate');
+        $c->select($this->modx->getSelectColumns('FredThemedTemplate', 'FredThemedTemplate', '', ['template']));
+        $c->prepare();
+        $c->stmt->execute();
+
+        $templates = $c->stmt->fetchAll(\PDO::FETCH_COLUMN, 0);
+        $templates = array_map('intval', $templates);
+        $templates = array_filter($templates);
+
+        if (empty($templates)) {
+            return $this->failure($this->modx->lexicon('fred.refresh_fail_template'));
+        }
+
+        $count = $this->modx->getCount('modResource', ['template:IN' => $templates]);
+
+        return $this->success('', ['total' => (int)$count]);
+    }
+}

--- a/core/components/fred/src/v2/Processors/Generate/Count.php
+++ b/core/components/fred/src/v2/Processors/Generate/Count.php
@@ -15,8 +15,13 @@ class Count extends \modProcessor
 
     public function process()
     {
+        $theme = (int)$this->getProperty('theme', 0);
+
         $c = $this->modx->newQuery('FredThemedTemplate');
         $c->select($this->modx->getSelectColumns('FredThemedTemplate', 'FredThemedTemplate', '', ['template']));
+        if ($theme > 0) {
+            $c->where(['theme' => $theme]);
+        }
         $c->prepare();
         $c->stmt->execute();
 

--- a/core/components/fred/src/v2/Processors/Generate/Refresh.php
+++ b/core/components/fred/src/v2/Processors/Generate/Refresh.php
@@ -20,6 +20,7 @@ class Refresh extends \modProcessor
         $offset = (int)$this->getProperty('offset', 0);
         $limit = (int)$this->getProperty('limit', 10);
         $isLast = (bool)$this->getProperty('isLast', false);
+        $theme = (int)$this->getProperty('theme', 0);
 
         /** @var \Fred $fred */
         $corePath = $this->modx->getOption('fred.core_path', null, $this->modx->getOption('core_path', null, MODX_CORE_PATH) . 'components/fred/');
@@ -38,6 +39,9 @@ class Refresh extends \modProcessor
 
         $c = $this->modx->newQuery('FredThemedTemplate');
         $c->select($this->modx->getSelectColumns('FredThemedTemplate', 'FredThemedTemplate', '', ['template']));
+        if ($theme > 0) {
+            $c->where(['theme' => $theme]);
+        }
 
         $c->prepare();
         $c->stmt->execute();

--- a/core/components/fred/src/v2/Processors/Generate/Refresh.php
+++ b/core/components/fred/src/v2/Processors/Generate/Refresh.php
@@ -15,8 +15,12 @@ class Refresh extends \modProcessor
 
     public function process()
     {
-        //allow larger sites to rebuild
-        ini_set('max_execution_time', 300);
+        ini_set('max_execution_time', 30);
+
+        $offset = (int)$this->getProperty('offset', 0);
+        $limit = (int)$this->getProperty('limit', 10);
+        $isLast = (bool)$this->getProperty('isLast', false);
+
         /** @var \Fred $fred */
         $corePath = $this->modx->getOption('fred.core_path', null, $this->modx->getOption('core_path', null, MODX_CORE_PATH) . 'components/fred/');
         $fred = $this->modx->getService(
@@ -28,8 +32,9 @@ class Refresh extends \modProcessor
             ]
         );
 
-        //Clear Element Values
-        $this->modx->removeCollection('FredCache', []);
+        if ($offset === 0) {
+            $this->modx->removeCollection('FredCache', []);
+        }
 
         $c = $this->modx->newQuery('FredThemedTemplate');
         $c->select($this->modx->getSelectColumns('FredThemedTemplate', 'FredThemedTemplate', '', ['template']));
@@ -47,6 +52,7 @@ class Refresh extends \modProcessor
 
         $c = $this->modx->newQuery('modResource');
         $c->where(['template:IN' => $templates]);
+        $c->limit($limit, $offset);
         $results = $this->modx->getIterator('modResource', $c);
 
         foreach ($results as $resource) {
@@ -89,7 +95,9 @@ class Refresh extends \modProcessor
             $this->modx->log(\modX::LOG_LEVEL_INFO, $this->modx->lexicon('fred.refresh_id', ['id' => $resource->id]));
         }
 
-        $this->modx->log(\modX::LOG_LEVEL_INFO, $this->modx->lexicon('fred.refresh_complete'));
+        if ($isLast) {
+            $this->modx->log(\modX::LOG_LEVEL_INFO, $this->modx->lexicon('fred.refresh_complete'));
+        }
 
         return $this->success('');
     }


### PR DESCRIPTION
This helps resolve issues where regeneration fails due to timeout. It gets a total count of resources during regeneration and iterates through them. 